### PR TITLE
Tweaks to ECR integration

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,18 +1,11 @@
-module "vpc" {
-  source                = "github.com/davidmcclure/tf-aws-vpc"
-  name                  = var.name
-  aws_region            = var.aws_region
-  aws_availability_zone = var.aws_availability_zone
-}
-
 provider "aws" {
-  region = module.vpc.aws_region
+  region = var.aws_region
 }
 
 resource "aws_security_group" "spark" {
   name        = var.name
   description = "Standalone Spark cluster"
-  vpc_id      = module.vpc.vpc_id
+  vpc_id      = var.vpc_id
 
   ingress {
     from_port   = 22
@@ -93,7 +86,7 @@ resource "aws_key_pair" "spark" {
 resource "aws_instance" "master" {
   ami                         = var.docker_ami
   instance_type               = var.master_instance_type
-  subnet_id                   = module.vpc.subnet_id
+  subnet_id                   = var.subnet_id
   vpc_security_group_ids      = [aws_security_group.spark.id]
   key_name                    = aws_key_pair.spark.key_name
   associate_public_ip_address = true
@@ -110,7 +103,7 @@ resource "aws_instance" "master" {
 resource "aws_spot_instance_request" "worker" {
   ami                         = var.docker_ami
   instance_type               = var.worker_instance_type
-  subnet_id                   = module.vpc.subnet_id
+  subnet_id                   = var.subnet_id
   vpc_security_group_ids      = [aws_security_group.spark.id]
   key_name                    = aws_key_pair.spark.key_name
   spot_price                  = var.spot_price
@@ -147,4 +140,3 @@ resource "local_file" "master_ip" {
   content  = aws_instance.master.public_ip
   filename = "${path.module}/.master-ip"
 }
-

--- a/terraform/roles/spark/defaults/main.yml
+++ b/terraform/roles/spark/defaults/main.yml
@@ -41,6 +41,9 @@ spark_docker_env:
 
 spark_openblas_num_threads: 1
 
+spark_ecr_login: false
+spark_ecr_region: us-east-1
+
 # Provide locally.
 aws_access_key_id: null
 aws_secret_access_key: null

--- a/terraform/roles/spark/defaults/main.yml
+++ b/terraform/roles/spark/defaults/main.yml
@@ -39,7 +39,7 @@ spark_max_files: 100000
 spark_docker_env:
   SPARK_ENV: prod
 
-openblas_num_threads: 1
+spark_openblas_num_threads: 1
 
 # Provide locally.
 aws_access_key_id: null

--- a/terraform/roles/spark/tasks/main.yml
+++ b/terraform/roles/spark/tasks/main.yml
@@ -38,9 +38,11 @@
 
 # TODO: Check for ecr_login boolean flag. Break into separate file.
 
-# TODO: Provide login command directly, set ENV via Ansible?
 - name: Login to AWS ECR
-  command: sh /home/{{ ansible_user }}/docker-login.sh
+  shell: $(aws ecr get-login --no-include-email --region us-east-1)
+  environment:
+    AWS_ACCESS_KEY_ID: '{{ aws_access_key_id }}'
+    AWS_SECRET_ACCESS_KEY: '{{ aws_secret_access_key }}'
 
 - name: Start master
   include_tasks: start_container.yml

--- a/terraform/roles/spark/tasks/main.yml
+++ b/terraform/roles/spark/tasks/main.yml
@@ -20,6 +20,7 @@
     - spark-env.sh
     - log4j.properties
 
+# TODO: No need for docker-login, if we use `command` directly.
 - name: Render scripts
   template:
     src: '{{ item }}.j2'
@@ -27,6 +28,7 @@
     owner: '{{ ansible_user }}'
     mode: u+x
   with_items:
+    # TODO: Something broken with docker-bash.sh
     - docker-bash.sh
     - docker-login.sh
 
@@ -35,6 +37,8 @@
     path: /home/{{ ansible_user }}/.bashrc
     line: source ./docker-bash.sh
 
+# TODO: Fix in Docker AMI build.
+
 # Super annoying issue regarding 'unattended-upgrades' on the AMI.  See
 # https://github.com/ansible/ansible/issues/25414.  This can and does slow down
 # deployment, unfortunately.  A more appropriate solution, given the simple use
@@ -42,13 +46,16 @@
 # and find a good way to pass the docker login token to Ansible, find another
 # way to install awscli (that doesn't take even longer), or create an AMI with
 # awscli already installed (and possibly with 'unattended-upgrades' disabled).
-- name: Wait for any possibly running unattended upgrade to finish
-  raw: systemd-run --property="After=apt-daily.service apt-daily-upgrade.service" --wait /bin/true
+# - name: Wait for any possibly running unattended upgrade to finish
+#   raw: systemd-run --property="After=apt-daily.service apt-daily-upgrade.service" --wait /bin/true
+
+# TODO: Check for ecr_login boolean flag. Break into separate file.
 
 - name: Install awscli
   apt:
     name: awscli
 
+# TODO: Provide login command directly, set ENV via Ansible?
 - name: Login to AWS ECR
   command: sh /home/{{ ansible_user }}/docker-login.sh
 

--- a/terraform/roles/spark/tasks/main.yml
+++ b/terraform/roles/spark/tasks/main.yml
@@ -28,7 +28,6 @@
     owner: '{{ ansible_user }}'
     mode: u+x
   with_items:
-    # TODO: Something broken with docker-bash.sh
     - docker-bash.sh
     - docker-login.sh
 
@@ -37,22 +36,7 @@
     path: /home/{{ ansible_user }}/.bashrc
     line: source ./docker-bash.sh
 
-# Super annoying issue regarding 'unattended-upgrades' on the AMI.  See
-# https://github.com/ansible/ansible/issues/25414.  This can and does slow down
-# deployment, unfortunately.  A more appropriate solution, given the simple use
-# case of just needing awscli, would probably be to either run awscli locally
-# and find a good way to pass the docker login token to Ansible, find another
-# way to install awscli (that doesn't take even longer), or create an AMI with
-# awscli already installed (and possibly with 'unattended-upgrades' disabled).
-# - name: Wait for any possibly running unattended upgrade to finish
-#   raw: systemd-run --property="After=apt-daily.service apt-daily-upgrade.service" --wait /bin/true
-
 # TODO: Check for ecr_login boolean flag. Break into separate file.
-
-# TODO: Do in Docker AMI build.
-- name: Install awscli
-  apt:
-    name: awscli
 
 # TODO: Provide login command directly, set ENV via Ansible?
 - name: Login to AWS ECR

--- a/terraform/roles/spark/tasks/main.yml
+++ b/terraform/roles/spark/tasks/main.yml
@@ -37,8 +37,6 @@
     path: /home/{{ ansible_user }}/.bashrc
     line: source ./docker-bash.sh
 
-# TODO: Fix in Docker AMI build.
-
 # Super annoying issue regarding 'unattended-upgrades' on the AMI.  See
 # https://github.com/ansible/ansible/issues/25414.  This can and does slow down
 # deployment, unfortunately.  A more appropriate solution, given the simple use
@@ -51,6 +49,7 @@
 
 # TODO: Check for ecr_login boolean flag. Break into separate file.
 
+# TODO: Do in Docker AMI build.
 - name: Install awscli
   apt:
     name: awscli

--- a/terraform/roles/spark/tasks/main.yml
+++ b/terraform/roles/spark/tasks/main.yml
@@ -20,16 +20,12 @@
     - spark-env.sh
     - log4j.properties
 
-# TODO: No need for docker-login, if we use `command` directly.
-- name: Render scripts
+- name: Render Docker bash script
   template:
-    src: '{{ item }}.j2'
-    dest: '/home/{{ ansible_user }}/{{ item }}'
+    src: docker-bash.sh.j2
+    dest: /home/{{ ansible_user }}/docker-bash.sh
     owner: '{{ ansible_user }}'
     mode: u+x
-  with_items:
-    - docker-bash.sh
-    - docker-login.sh
 
 - name: Automatically connect to container on login
   lineinfile:
@@ -39,6 +35,7 @@
 # TODO: Check for ecr_login boolean flag. Break into separate file.
 
 - name: Login to AWS ECR
+  # TODO: ecr_region variable
   shell: $(aws ecr get-login --no-include-email --region us-east-1)
   environment:
     AWS_ACCESS_KEY_ID: '{{ aws_access_key_id }}'

--- a/terraform/roles/spark/tasks/main.yml
+++ b/terraform/roles/spark/tasks/main.yml
@@ -35,8 +35,10 @@
 # TODO: Check for ecr_login boolean flag. Break into separate file.
 
 - name: Login to AWS ECR
-  # TODO: ecr_region variable
-  shell: $(aws ecr get-login --no-include-email --region us-east-1)
+  shell: >
+    $(aws ecr get-login --no-include-email
+    --region {{ spark_ecr_region }})
+  when: spark_ecr_login
   environment:
     AWS_ACCESS_KEY_ID: '{{ aws_access_key_id }}'
     AWS_SECRET_ACCESS_KEY: '{{ aws_secret_access_key }}'

--- a/terraform/roles/spark/templates/docker-bash.sh.j2
+++ b/terraform/roles/spark/templates/docker-bash.sh.j2
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CONTAINER_ID=$(sudo docker ps -f "name=spark" | sed -n 2p | grep -o '[0-9a-z]\{12\}')
+CONTAINER_ID=$(sudo docker ps -aqf "name=spark-master")
 
 DOCKER_CMD="sudo docker exec -it ${CONTAINER_ID} bash"
 

--- a/terraform/roles/spark/templates/docker-login.sh.j2
+++ b/terraform/roles/spark/templates/docker-login.sh.j2
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-export AWS_ACCESS_KEY_ID={{ aws_access_key_id }} AWS_SECRET_ACCESS_KEY={{ aws_secret_access_key }}
-$(aws ecr get-login --no-include-email --region us-east-1)
-unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY

--- a/terraform/roles/spark/templates/spark-env.sh.j2
+++ b/terraform/roles/spark/templates/spark-env.sh.j2
@@ -17,6 +17,6 @@ ulimit -n {{ spark_max_files - 1 }}
 PYTHONHASHSEED=1
 
 # Prevent SpaCy from spawning threads.
-OPENBLAS_NUM_THREADS={{ openblas_num_threads }}
+OPENBLAS_NUM_THREADS={{ spark_openblas_num_threads }}
 
 SPARK_WORKER_DIR={{ spark_worker_dir }}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -10,9 +10,16 @@ variable "aws_availability_zone" {
   default = "us-east-1a"
 }
 
-# TODO: Null value, in TF 0.12?
+variable "vpc_id" {
+  type = "string"
+}
+
+variable "subnet_id" {
+  type = "string"
+}
+
 variable "docker_ami" {
-  default     = "ami-XXX"
+  type = "string"
   description = "AMI with Docker."
 }
 
@@ -55,4 +62,3 @@ variable "driver_max_result_size" {
 variable "executor_memory" {
   default = "40g"
 }
-


### PR DESCRIPTION
A couple of small tweaks to the ECR login:

- Move the `awscli` install into the [Docker AMI build](https://github.com/davidmcclure/docker-ami/blob/master/deploy.yml#L33), so we just do it once and then don't have to worry about it here.

- Run the `aws ecr get-login` command via Ansible's `shell` module. This isn't functionally different from the bash script, but avoids the extra step of copying up the script.

- Adds `spark_ecr_login` (boolean) and `spark_ecr_region` (default us-east-1) Ansible variables, so the user can control whether the ECR login happens. So, in our case, in the local.yml, we just have:

```yaml
spark_docker_image: XXX.dkr.ecr.us-east-1.amazonaws.com/XXX
spark_ecr_login: yes
```

- Previously, I was creating an ephemeral VPC for every cluster, via a separate Terraform module that got pulled in from GitHub. This was because ~2 years ago it took like 5 manual steps to create a VPC + subnet + gateway + etc, but now there's a single-click wizard that makes this super easy (I may have just not known about this before...), so the Terraform solution feels like overkill. This also makes the TF runs somewhat faster, since we just create the instances. This means that we need to provide VPC / subnet ids in `local.auto.tfvars`:

```hcl
vpc_id = "vpc-XXX"
subnet_id = "subnet-XX"
```