### PR TITLE
Use no root flag for poetry install

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 terraform init
-poetry install
+poetry install --no-root


### PR DESCRIPTION
With newer versions of Poetry, explicit use of `--no-root` flag is required for correctly install the environment for deployment.