### PR TITLE
Set `package-mode = false`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = ""
 authors = ["David McClure <davidwilliammcclure@gmail.com>"]
 readme = "README.md"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.10"


### PR DESCRIPTION
Related: https://github.com/opensyllabus/pyspark-deploy/pull/3

> With newer versions of Poetry, explicit use of --no-root flag is required for correctly install the environment for deployment.

Instead of using `--no-root` flag, we set `package-mode` to `false` explicitly in `pyproject.toml`