### PR TITLE
Increase the SSH timeout to 600 seconds

### DIFF
--- a/cluster.py
+++ b/cluster.py
@@ -76,7 +76,7 @@ class Cluster:
         """
         client = paramiko.SSHClient()
         client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        client.connect(self.master_dns, username='ubuntu', timeout=60*3)
+        client.connect(self.master_dns, username='ubuntu', timeout=60*10)
         return client
 
     def cat_cloudinit_log(self) -> str:


### PR DESCRIPTION
The SSH connection can timeout while the instance is getting ready. This happens quite often for me which requires me to run `./cluster.sh create` more times to keep the logs going. 

https://github.com/opensyllabus/pyspark-deploy/blob/ea710f68e9901db023a47e7a87cd965838432cec/cluster.py#L85

https://github.com/opensyllabus/pyspark-deploy/blob/ea710f68e9901db023a47e7a87cd965838432cec/cluster.py#L92

